### PR TITLE
modify PerformRequest() to allow arbitrary modifiers

### DIFF
--- a/requester.go
+++ b/requester.go
@@ -1,8 +1,6 @@
 package testflight
 
 import (
-	"fmt"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"

--- a/requester.go
+++ b/requester.go
@@ -1,6 +1,8 @@
 package testflight
 
 import (
+	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -11,24 +13,24 @@ type Requester struct {
 	server *httptest.Server
 }
 
-func (requester *Requester) Get(route string) *Response {
-	return requester.performRequest("GET", route, "", "")
+func (requester *Requester) Get(route string, mods ...func(*http.Request) error) *Response {
+	return requester.performRequest("GET", route, "", "", mods...)
 }
 
-func (requester *Requester) Post(route, contentType, body string) *Response {
-	return requester.performRequest("POST", route, contentType, body)
+func (requester *Requester) Post(route, contentType, body string, mods ...func(*http.Request) error) *Response {
+	return requester.performRequest("POST", route, contentType, body, mods...)
 }
 
-func (requester *Requester) Put(route, contentType, body string) *Response {
-	return requester.performRequest("PUT", route, contentType, body)
+func (requester *Requester) Put(route, contentType, body string, mods ...func(*http.Request) error) *Response {
+	return requester.performRequest("PUT", route, contentType, body, mods...)
 }
 
-func (requester *Requester) Patch(route, contentType, body string) *Response {
-	return requester.performRequest("PATCH", route, contentType, body)
+func (requester *Requester) Patch(route, contentType, body string, mods ...func(*http.Request) error) *Response {
+	return requester.performRequest("PATCH", route, contentType, body, mods...)
 }
 
-func (requester *Requester) Delete(route, contentType, body string) *Response {
-	return requester.performRequest("DELETE", route, contentType, body)
+func (requester *Requester) Delete(route, contentType, body string, mods ...func(*http.Request) error) *Response {
+	return requester.performRequest("DELETE", route, contentType, body, mods...)
 }
 
 func (requester *Requester) Do(request *http.Request) *Response {
@@ -45,10 +47,18 @@ func (requester *Requester) Url(route string) string {
 	return requester.server.Listener.Addr().String() + route
 }
 
-func (requester *Requester) performRequest(httpAction, route, contentType, body string) *Response {
+func (requester *Requester) performRequest(httpAction, route, contentType, body string, mods ...func(*http.Request) error) *Response {
 	request, err := http.NewRequest(httpAction, requester.httpUrl(route), strings.NewReader(body))
 	if err != nil {
 		panic(err)
+	}
+	// call each modifier so they can manipulate our request before sending
+	// if a modifier fails we panic on its error code
+	for _, op := range mods {
+		err := op(request)
+		if err != nil {
+			panic(err)
+		}
 	}
 
 	request.Header.Add("Content-Type", contentType)


### PR DESCRIPTION
Hi there!

I modified the testflight Requester to be able to register arbitrary modifier functions...

This does not change the default usage as the new argument is a variadic, but it enables a new use case like this one:

```go
import (
    "net/http"
    "time"

   "github.com/drewolson/testflight"
)

func addCookie(r *http.Request) error {
        // create a http.Cookie named c
	c := http.Cookie{
		Name:     "myapp_session_cookie",
		Value:    "some_value",
		Expires: time.Now().AddDate(0, 1, 0),
		MaxAge:   86400,
		Secure:   true,
		HttpOnly: true,
	}
	r.AddCookie(&c)
	return nil
}

func TestGet(t *testing.T) {
    testflight.WithServer(Handler(), func(r *testflight.Requester) {
        response := r.Get("/hello/drew", addCookie)

        assert.Equal(t, 200, response.StatusCode)
        assert.Equal(t, "hello, drew", response.Body)
    })
}
```

I have looked at your unit tests and think I could write a test for this functionality if you want. Please tell me if you are interested in this PR so I can invest more time to write the tests if they are needed :)